### PR TITLE
Fix unused import in Overview.tsx causing build failure

### DIFF
--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -9,7 +9,6 @@ import {
     endOfYear,
     parseISO,
     eachDayOfInterval,
-    isSameDay,
     startOfDay,
     endOfDay
 } from 'date-fns';


### PR DESCRIPTION
Removed `isSameDay` from `src/pages/Overview.tsx` import as it was unused and causing a build failure. Verified that `npm run build` now completes successfully.

---
*PR created automatically by Jules for task [2560282502016600907](https://jules.google.com/task/2560282502016600907) started by @tibame201020*